### PR TITLE
Fix missing copy statement 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1
 FROM python:3.7-alpine
 WORKDIR /code
-ENV FLASK_APP=app.py
+COPY MUDIS MUDIS
+ENV FLASK_APP=./MUDIS/app.py
 ENV FLASK_RUN_HOST=0.0.0.0
 RUN apk add --no-cache gcc musl-dev linux-headers
 COPY requirements.txt requirements.txt


### PR DESCRIPTION
Hi @ransh93 , 
When we try run MUDIS it fails with the following error:
```cmd
web_1                | Traceback (most recent call last):
web_1                |   File "/usr/local/lib/python3.7/site-packages/flask/cli.py", line 343, in __call__
web_1                |     rv = self._load_unlocked()
web_1                |   File "/usr/local/lib/python3.7/site-packages/flask/cli.py", line 330, in _load_unlocked
web_1                |     self._app = rv = self.loader()
web_1                |   File "/usr/local/lib/python3.7/site-packages/flask/cli.py", line 388, in load_app
web_1                |     app = locate_app(self, import_name, name)
web_1                |   File "/usr/local/lib/python3.7/site-packages/flask/cli.py", line 250, in locate_app
web_1                |     raise NoAppException('Could not import "{name}".'.format(name=module_name))
web_1                | flask.cli.NoAppException: Could not import "app".
```

I'm not a docker-compose expert but I do work with docker and noticed that the application code is not copied to the docker file. 